### PR TITLE
Add Frontend__Url env var and update Angular build budgets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ Jwt__Issuer=taskboard
 Jwt__Audience=account
 SlackApp__Token=<oauth-token>
 SlackApp__ChannelId=<channelId>
+Frontend__Url=http://localhost:4200

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ Jwt__Issuer=taskboard
 Jwt__Audience=account
 SlackApp__Token=<oauth-token>
 SlackApp__ChannelId=<channelId>
+Frontend__Url=http://localhost:4200

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
       - Jwt__Secret=${Jwt__Secret};
       - Jwt__Issuer=${Jwt__Issuer};
       - Jwt__Audience=${Jwt__Audience};
+      - SlackApp__Token=${SlackApp__Token};
+      - SlackApp__ChannelId=${SlackApp__ChannelId};
+      - Frontend__Url=${Frontend__Url};
     depends_on:
       taskboard-postgres:
         condition: service_healthy

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -39,8 +39,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1.5MB",
+                  "maximumError": "1.5MB"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
Introduced the Frontend__Url environment variable to both .env.example files and passed it to the backend service in docker-compose.yaml. Also increased the Angular build size budgets in angular.json to 1.5MB for both warning and error thresholds.